### PR TITLE
解决通过composer引入的PHPUnit做单元测试时无法自定义设置的问题

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,6 @@
   "autoload": {
     "classmap": [
       "/"
-    ],
-    "files": [
-      "ko.class.php"
     ]
   },
   "authors": [


### PR DESCRIPTION
去掉在composer的autoload中加载ko.class.php。  
原因是在使用通过composer引入的PHPUnit时，ko.class.php中的配置总是会被优先加载，无法自定义一些设置。  
现在需要手动在合适的时机自己引入。